### PR TITLE
adding markdown official support

### DIFF
--- a/SwiftyMimeTypes/Assets/mime.types
+++ b/SwiftyMimeTypes/Assets/mime.types
@@ -688,6 +688,7 @@ text/calendar ics ifb
 text/css css
 text/csv csv
 text/html html htm
+text/markdown md
 text/n3 n3
 text/plain txt text conf def list log in
 text/prs.lines.tag dsc


### PR DESCRIPTION
As of March 2016

`text/markdown` to `.md` is official see https://tools.ietf.org/html/rfc7763